### PR TITLE
Merge updated JSON messages into Hive current table

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,13 +1,17 @@
-name := "sparkTesting"
+name := "sparkMerge"
 
 version := "1.0"
 
-scalaVersion := "2.11.1"
+scalaVersion := "2.11.12"
+
+val sparkVersion = "2.2.0.cloudera1"
+
+resolvers += "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/"
 
 libraryDependencies ++= Seq(
-  "org.apache.spark" %% "spark-core" % "2.1.0",
-  "org.apache.spark" %% "spark-sql" % "2.1.0",
+  "org.apache.spark" %% "spark-core" % sparkVersion % "provided",
+  "org.apache.spark" %% "spark-sql" % sparkVersion % "provided",
   "org.scalatest" %% "scalatest" % "2.2.6" % "test",
-  "org.apache.spark" %% "spark-hive" % "2.1.0"
-
+  "org.apache.spark" %% "spark-hive" % sparkVersion % "provided",
+  "org.rogach" %% "scallop" % "3.1.2"
 )

--- a/src/main/scala/HiveMergeJson.scala
+++ b/src/main/scala/HiveMergeJson.scala
@@ -1,0 +1,48 @@
+package sparktest
+
+import org.rogach.scallop._
+import org.apache.spark.sql.{SparkSession, SaveMode}
+
+class Conf(arguments: Seq[String]) extends ScallopConf(arguments) {
+  val tableName = opt[String](required = true)
+  val updateFilePath = opt[String](required = true)
+  val uniqueKey = opt[String](required = true)
+  val orderColumn = opt[String](required = true)
+  verify()
+}
+
+object HiveMergeJson {
+  def main(args: Array[String]): Unit = {
+    val spark = SparkSession
+      .builder()
+      .enableHiveSupport()
+      .appName("spark-json-merge")
+      .master("yarn")
+      .getOrCreate()
+
+    val conf = new Conf(args)
+
+    val mergeTableName = conf.tableName() + "_merge"
+
+    val currentTable = spark.sql("SELECT * FROM " + conf.tableName())
+
+    val jsonUpdate = spark.read.json(conf.updateFilePath())
+    val jsonUpdateLower = jsonUpdate.toDF(jsonUpdate.columns map(_.toLowerCase): _*)
+
+    val uniqueKeys = conf.uniqueKey().split(",").map(_.trim).mkString(", ")
+    val primaryKey = Seq(s"$uniqueKeys")
+    val timestampColumn = conf.orderColumn()
+
+    val selectColumns = currentTable.columns
+    val jsonUpdateLowerOrdered = jsonUpdateLower.select(selectColumns.head, selectColumns.tail: _*)
+
+    val records = currentTable.union(jsonUpdateLowerOrdered)
+
+    MergeDriver.merge(primaryKey, timestampColumn, records)
+      .write
+      .mode(SaveMode.Overwrite)
+      .saveAsTable(s"$mergeTableName")
+
+    spark.stop()
+  }
+}


### PR DESCRIPTION
This code adds the ability to specify command line options to the Scala code to identify the information needed to update a Hive table.  The messages that are to be updated are in JSON on HDFS and will use a unique key to identify order when dealing with the entire message history.